### PR TITLE
Dependent fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A dynamic form builder for Vue.js with Ionic components
 - [Form Methods](#form-methods)
 - [Input Dependencies](#input-dependencies)
   - [Dynamic Options](#dynamic-options)
+  - [Resetting Dependent Fields](#resetting-dependent-fields)
 - [Advanced Components](#advanced-components)
   - [SelectInput](#selectinput)
   - [Custom Buttons](#custom-buttons)
@@ -424,6 +425,80 @@ An input can also depend on multiple other inputs:
 ```
 
 For more details and examples, see the [Dependencies Documentation](./docs/DEPENDENCIES.md).
+
+#### Resetting Dependent Fields
+
+When a dependency changes, you often want to reset the dependent field's value to prevent invalid combinations (e.g., when changing from "USA" to "Canada", the previously selected "California" state should be cleared).
+
+**Method 1: Automatic Reset (Built-in)**
+
+The SelectInput component automatically detects dependency changes and resets the field value when using the `dependsOn` property:
+
+```javascript
+const formSchema = {
+  country: {
+    type: 'SelectInput',
+    label: 'Country',
+    options: [
+      { label: 'United States', value: 'us' },
+      { label: 'Canada', value: 'ca' },
+    ],
+  },
+  state: {
+    type: 'SelectInput',
+    label: 'State/Province',
+    dependsOn: 'country',
+    options: (filter, dependencyValues) => {
+      const country = dependencyValues?.country?.value;
+      return getStatesForCountry(country);
+    },
+  },
+};
+```
+
+When the country changes, the state field automatically resets to empty and reloads options.
+
+**Method 2: Manual Reset (Workaround)**
+
+If the automatic reset doesn't work as expected, you can manually reset dependent fields using the `onChange` callback:
+
+```javascript
+{
+  country: {
+    type: 'SelectInput',
+    label: 'Country',
+    options: [...],
+    onChange: (value, schema) => {
+      // Manual reset as workaround
+      schema.state.value = '';
+      return value;
+    },
+  }
+}
+```
+
+**Method 3: Multiple Field Reset**
+
+You can reset multiple dependent fields at once using onChange:
+
+```javascript
+{
+  country: {
+    type: 'SelectInput',
+    label: 'Country',
+    options: [...],
+    onChange: (value, schema) => {
+      // Reset all location-dependent fields
+      schema.state.value = '';
+      schema.city.value = '';
+      schema.zipCode.value = '';
+      return value;
+    },
+  }
+}
+```
+
+**Note:** Use the onChange approach as a workaround when the automatic reset doesn't work properly, or when you need to reset multiple fields or perform additional logic when dependencies change.
 
 ### Advanced Components
 

--- a/demo/src/components/DependentFieldsDemo.vue
+++ b/demo/src/components/DependentFieldsDemo.vue
@@ -78,6 +78,64 @@
             </ion-list>
           </ion-card-content>
         </ion-card>
+
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>Resetting Dependent Fields</ion-card-title>
+            <ion-card-subtitle
+              >Best practices for clearing dependent field values</ion-card-subtitle
+            >
+          </ion-card-header>
+
+          <ion-card-content>
+            <p>
+              When a dependency changes, you often want to reset the dependent field's value to
+              prevent invalid combinations. The form library provides automatic reset functionality
+              with a manual workaround when needed.
+            </p>
+
+            <h4>Method 1: Automatic Reset (Built-in)</h4>
+            <p>
+              The SelectInput component automatically detects dependency changes and resets the
+              field value. This works automatically with the <code>dependsOn</code> property:
+            </p>
+            <pre><code>state: {
+  type: 'SelectInput',
+  label: 'State',
+  dependsOn: 'country',
+  options: (filter, dependencyValues) => {
+    // Returns options based on country
+    return getStatesForCountry(dependencyValues.country);
+  }
+}</code></pre>
+            <p>
+              When the country changes, the state field automatically resets to empty and reloads
+              options.
+            </p>
+
+            <h4>Method 2: Manual Reset (Workaround)</h4>
+            <p>
+              If the automatic reset doesn't work as expected, you can manually reset dependent
+              fields using the <code>onChange</code> callback:
+            </p>
+            <pre><code>country: {
+  type: 'SelectInput',
+  label: 'Country',
+  options: [...],
+  onChange: (value, schema) => {
+    // Manual reset as workaround
+    schema.state.value = '';
+    return value;
+  }
+}</code></pre>
+
+            <p>
+              <strong>Note:</strong> Use the onChange approach as a workaround when the automatic
+              reset doesn't work properly, or when you need to reset multiple fields or perform
+              additional logic when dependencies change.
+            </p>
+          </ion-card-content>
+        </ion-card>
       </div>
     </ion-content>
   </ion-page>
@@ -156,6 +214,11 @@ const formSchema: FormSchema = {
     ],
     required: true,
     grid: { xs: '12', md: '6' },
+    // Workaround: Reset dependent field when country changes
+    onChange: (value, schema) => {
+      schema.state.value = ''; // Reset state when country changes
+      return value;
+    },
   },
   state: {
     type: 'SelectInput',

--- a/src/components/inputs/SelectInput.vue
+++ b/src/components/inputs/SelectInput.vue
@@ -125,12 +125,9 @@ watch(
     return dependsOn.map(depId => props.schema![depId]?.value);
   },
   async (newValues, oldValues) => {
-    // Only trigger if we have both new and old values and they're different
     if (newValues && oldValues && !deepEqual(newValues, oldValues)) {
-      // Reset the field when dependencies change
       onReset();
-
-      // Reload options with new dependency values
+      options.value = [];
       await filterOptions();
     }
   },
@@ -143,6 +140,7 @@ function onReset() {
   page.value = 1;
   model.value.value = model.value.multiple ? [] : '';
   uncheckAllOptions(options.value);
+  console.log('SelectInput reset');
 }
 
 function onSelect(item: Option) {

--- a/src/components/inputs/SelectInput.vue
+++ b/src/components/inputs/SelectInput.vue
@@ -52,7 +52,14 @@
 import { ref, computed, PropType, watch, ComponentPublicInstance, onMounted } from 'vue';
 import { chevronDown, close } from 'ionicons/icons';
 import { FormSchema, BaseFieldTypes, FormField, Option } from '@/types';
-import { isEmpty, checkOption, getFilteredOptions, uncheckOption, deepEqual } from '@/utils';
+import {
+  isEmpty,
+  checkOption,
+  getFilteredOptions,
+  uncheckOption,
+  deepEqual,
+  uncheckAllOptions,
+} from '@/utils';
 import { useInputValidation } from '@/composables/useInputValidation';
 import {
   IonInput,
@@ -120,6 +127,10 @@ watch(
   async (newValues, oldValues) => {
     // Only trigger if we have both new and old values and they're different
     if (newValues && oldValues && !deepEqual(newValues, oldValues)) {
+      // Reset the field when dependencies change
+      onReset();
+
+      // Reload options with new dependency values
       await filterOptions();
     }
   },
@@ -127,11 +138,11 @@ watch(
 );
 
 function onReset() {
-  options.value.forEach(o => uncheckOption(o, options.value));
   model.value.error = '';
   filter.value = '';
   page.value = 1;
   model.value.value = model.value.multiple ? [] : '';
+  uncheckAllOptions(options.value);
 }
 
 function onSelect(item: Option) {

--- a/src/components/inputs/SelectInput.vue
+++ b/src/components/inputs/SelectInput.vue
@@ -140,7 +140,6 @@ function onReset() {
   page.value = 1;
   model.value.value = model.value.multiple ? [] : '';
   uncheckAllOptions(options.value);
-  console.log('SelectInput reset');
 }
 
 function onSelect(item: Option) {

--- a/src/components/vForm.vue
+++ b/src/components/vForm.vue
@@ -16,7 +16,6 @@
             :is="activeSchema[formId].type"
             v-model="activeSchema[formId]"
             :schema="activeSchema"
-            :dependency-manager="dependencyManager"
             :form-id="formId"
             ref="dynamicRefs"
             :ref-key="formId"
@@ -52,7 +51,6 @@ import type { FormData, ComputedData, FormSchema, CustomButton } from '@/types';
 import { canRenderField } from '@/utils';
 import { useFormValidation } from '@/composables/useFormValidation';
 import { useDataTransformation } from '@/composables/useDataTransformation';
-import { useDependentOptions } from '@/composables/useDependentOptions';
 
 interface FormProps {
   schema: FormSchema;
@@ -92,10 +90,6 @@ const { dynamicRefs, isFormValid, resetForm } = useFormValidation();
 
 // Use data transformation composable
 const { formData: data, computedData } = useDataTransformation(activeSchema);
-
-// Use dependent options composable
-type DependencyManager = ReturnType<typeof useDependentOptions>;
-const dependencyManager: DependencyManager = useDependentOptions(activeSchema, data, computedData);
 
 async function submitForm() {
   if (!(await isFormValid())) return;

--- a/src/composables/useDataTransformation.ts
+++ b/src/composables/useDataTransformation.ts
@@ -14,7 +14,7 @@ export function useDataTransformation(activeSchema: Ref<FormSchema>) {
     Object.entries(activeSchema.value).reduce((acc, [key, form]) => {
       if (form.value !== undefined) {
         if (typeof form.onChange === 'function') {
-          acc[key] = form.onChange(form.value);
+          acc[key] = form.onChange(form.value, activeSchema.value);
         } else {
           acc[key] = form.value;
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -331,6 +331,7 @@ export interface FormField {
    *
    * @param value - The new value of the form input field.
    * @param schema - The schema of the form.
+   * @returns {FormValue} The processed form value.
    */
   onChange?: (value: FormValue, schema: FormSchema) => FormValue;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -329,9 +329,10 @@ export interface FormField {
   /**
    * The custom function for listening to changes in the form input field.
    *
-   * @type ComputedValueHandler
+   * @param value - The new value of the form input field.
+   * @param schema - The schema of the form.
    */
-  onChange?: (value: FormValue) => FormValue;
+  onChange?: (value: FormValue, schema: FormSchema) => FormValue;
 
   /**
    * The custom function used for computing alternative values based on the current value of the form input field.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -148,6 +148,17 @@ export function uncheckOption(option: Option, options: Array<Option>) {
 }
 
 /**
+ * Unchecks all options in the provided array of options.
+ *
+ * @param {Array<Option>} options - The array of options to uncheck.
+ */
+export function uncheckAllOptions(options: Array<Option>) {
+  options.forEach(option => {
+    option.isChecked = false;
+  });
+}
+
+/**
  * Filters an array of options based on a provided filter string.
  *
  * @param {Array<Option>} options - The array of options to filter.

--- a/tests/unit/utils/index.spec.ts
+++ b/tests/unit/utils/index.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { uncheckAllOptions, deepEqual } from '../../../src/utils';
+import { Option } from '../../../src/types';
+
+describe('utils', () => {
+  describe('uncheckAllOptions', () => {
+    it('should uncheck all options when all options are checked', () => {
+      const options: Option[] = [
+        { label: 'Option 1', value: '1', isChecked: true },
+        { label: 'Option 2', value: '2', isChecked: true },
+        { label: 'Option 3', value: '3', isChecked: true },
+      ];
+
+      uncheckAllOptions(options);
+
+      expect(options.every(option => option.isChecked === false)).toBe(true);
+    });
+
+    it('should handle options with mixed checked states', () => {
+      const options: Option[] = [
+        { label: 'Option 1', value: '1', isChecked: true },
+        { label: 'Option 2', value: '2', isChecked: false },
+        { label: 'Option 3', value: '3', isChecked: true },
+      ];
+
+      uncheckAllOptions(options);
+
+      expect(options.every(option => option.isChecked === false)).toBe(true);
+    });
+
+    it('should handle empty options array', () => {
+      const options: Option[] = [];
+
+      uncheckAllOptions(options);
+
+      expect(options).toEqual([]);
+    });
+
+    it('should handle options where all are already unchecked', () => {
+      const options: Option[] = [
+        { label: 'Option 1', value: '1', isChecked: false },
+        { label: 'Option 2', value: '2', isChecked: false },
+      ];
+
+      uncheckAllOptions(options);
+
+      expect(options.every(option => option.isChecked === false)).toBe(true);
+    });
+
+    it('should preserve other option properties while unchecking', () => {
+      const options: Option[] = [
+        { label: 'Option 1', value: '1', isChecked: true, disabled: true },
+        { label: 'Option 2', value: '2', isChecked: true, other: { customProp: 'test' } },
+      ];
+
+      uncheckAllOptions(options);
+
+      expect(options[0]).toEqual({
+        label: 'Option 1',
+        value: '1',
+        isChecked: false,
+        disabled: true,
+      });
+      expect(options[1]).toEqual({
+        label: 'Option 2',
+        value: '2',
+        isChecked: false,
+        other: { customProp: 'test' },
+      });
+    });
+  });
+
+  describe('deepEqual', () => {
+    it('should return true for identical primitive values', () => {
+      expect(deepEqual(1, 1)).toBe(true);
+      expect(deepEqual('test', 'test')).toBe(true);
+      expect(deepEqual(true, true)).toBe(true);
+      expect(deepEqual(null, null)).toBe(true);
+      expect(deepEqual(undefined, undefined)).toBe(true);
+    });
+
+    it('should return false for different primitive values', () => {
+      expect(deepEqual(1, 2)).toBe(false);
+      expect(deepEqual('test', 'other')).toBe(false);
+      expect(deepEqual(true, false)).toBe(false);
+      expect(deepEqual(null, undefined)).toBe(false);
+    });
+
+    it('should return true for deeply equal objects', () => {
+      const obj1 = { a: 1, b: { c: 2, d: [3, 4] } };
+      const obj2 = { a: 1, b: { c: 2, d: [3, 4] } };
+      expect(deepEqual(obj1, obj2)).toBe(true);
+    });
+
+    it('should return false for objects with different values', () => {
+      const obj1 = { a: 1, b: { c: 2 } };
+      const obj2 = { a: 1, b: { c: 3 } };
+      expect(deepEqual(obj1, obj2)).toBe(false);
+    });
+
+    it('should return true for deeply equal arrays', () => {
+      const arr1 = [1, 2, { a: 3 }];
+      const arr2 = [1, 2, { a: 3 }];
+      expect(deepEqual(arr1, arr2)).toBe(true);
+    });
+
+    it('should return false for arrays with different lengths', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [1, 2];
+      expect(deepEqual(arr1, arr2)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces enhancements to the dynamic form builder for Vue.js with Ionic components, focusing on improving the handling of dependent fields and simplifying dependency management. Key changes include adding automatic and manual reset functionality for dependent fields, removing the `DependencyManager` abstraction, and updating the `onChange` callback to provide access to the form schema.

### Enhancements to dependent field handling:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34): Added documentation on resetting dependent fields, including built-in automatic resets and manual reset workarounds using the `onChange` callback. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R429-R502)
* [`demo/src/components/DependentFieldsDemo.vue`](diffhunk://#diff-90e81a9c6798a6af988d0eb81256e28073b2f2c90b163ec1e85451af769adccdR81-R138): Updated the demo to showcase best practices for resetting dependent fields, including examples of automatic and manual resets. [[1]](diffhunk://#diff-90e81a9c6798a6af988d0eb81256e28073b2f2c90b163ec1e85451af769adccdR81-R138) [[2]](diffhunk://#diff-90e81a9c6798a6af988d0eb81256e28073b2f2c90b163ec1e85451af769adccdR217-R221)
* [`src/components/inputs/SelectInput.vue`](diffhunk://#diff-406ab947d574f3ace8db9395fd693dc778d7a11c8fb17848bc8e5c3f60546102L54-R62): Introduced a watcher to detect dependency changes and refresh options, added `uncheckAllOptions` for resetting selections, and updated `filterOptions` to handle dependency values directly. [[1]](diffhunk://#diff-406ab947d574f3ace8db9395fd693dc778d7a11c8fb17848bc8e5c3f60546102L54-R62) [[2]](diffhunk://#diff-406ab947d574f3ace8db9395fd693dc778d7a11c8fb17848bc8e5c3f60546102R113-R143) [[3]](diffhunk://#diff-406ab947d574f3ace8db9395fd693dc778d7a11c8fb17848bc8e5c3f60546102L284-R331)

### Simplification of dependency management:
* [`src/components/inputs/SelectInput.vue`](diffhunk://#diff-406ab947d574f3ace8db9395fd693dc778d7a11c8fb17848bc8e5c3f60546102L71-L83): Removed `DependencyManager` abstraction and integrated dependency handling directly into the `SelectInput` component. [[1]](diffhunk://#diff-406ab947d574f3ace8db9395fd693dc778d7a11c8fb17848bc8e5c3f60546102L71-L83) [[2]](diffhunk://#diff-406ab947d574f3ace8db9395fd693dc778d7a11c8fb17848bc8e5c3f60546102L326-R359)
* [`src/components/vForm.vue`](diffhunk://#diff-462b48bb0b9ab42f7907c8c6284541aa6f2176f08261a34ce73bdc799eb34cc2L19): Removed usage of the `useDependentOptions` composable and associated `DependencyManager`. [[1]](diffhunk://#diff-462b48bb0b9ab42f7907c8c6284541aa6f2176f08261a34ce73bdc799eb34cc2L19) [[2]](diffhunk://#diff-462b48bb0b9ab42f7907c8c6284541aa6f2176f08261a34ce73bdc799eb34cc2L55) [[3]](diffhunk://#diff-462b48bb0b9ab42f7907c8c6284541aa6f2176f08261a34ce73bdc799eb34cc2L96-L99)

### Updates to `onChange` callback:
* [`src/types/index.ts`](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476L332-R335): Modified the `onChange` callback signature to include the form schema, enabling manual resets and additional logic based on dependency changes.
* [`src/composables/useDataTransformation.ts`](diffhunk://#diff-82bdb954d82421549b084dcf4655337e8606987c83a0a7c0a375b00894946addL17-R17): Updated `onChange` calls to pass the form schema as an argument.

### Utility improvements:
* [`src/utils/index.ts`](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99R150-R160): Added a new utility function `uncheckAllOptions` to simplify resetting all options in a field.